### PR TITLE
implement full unary operation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,11 @@
-#[cfg(not(feature="term"))]
 mod lexer;
-mod parser; 
+mod parser;
 mod term;
 use lexer::Lexer;
 use parser::{Parser, Node,ParserError}; // Import what you need from parser
 
 
-//use crate::term::Term;
+use crate::term::Term;
 
 
 fn main() {
@@ -66,11 +65,11 @@ fn main() {
 
     };
      
-       // let term1 = Term{term: node1.0.0,size:node1.0.1 };
+    let term1 = Term{term: node1.0.0,size:node1.0.1 };
           
-       // let rewrittenterm = term1.rewriteby(((&node2.0.0,node2.0.1),(&node2.1.0,node2.1.1)));
-      //  let term2 = Term{term:node2.0.0,size:node2.0.1};  
-       // println!("By the law \"{}\", \"{}\" => \"{}\"", term2, term1, rewrittenterm);
+    let rewrittenterm = term1.rewriteby(((&node2.0.0,node2.0.1),(&node2.1.0,node2.1.1)));
+    let term2 = Term{term:node2.0.0,size:node2.0.1};  
+        println!("By the law \"{}\", \"{}\" => \"{}\"", term2, term1, rewrittenterm);
     
 
     let rewrite_examples = vec![
@@ -91,12 +90,12 @@ fn main() {
         // Example 8: Another Commutativity (a + b = b + a)
         ("3 + x", "a + b = b + a"),
         // Example 9: Zero Multiplication (x * 0 = 0)
+        ("-(2+3)","-(a+b) = -a + -b "),
         ("y * 0", "x * 0 = 0"),
         // Example 10: Complex expression with multiple potential matches (only one applies per pass)
         ("(a + 0) * (b + 0)", "x + 0 = x"), // Should simplify both sides
     ];
-}
-   /*  for (i, (term_str, rule_str)) in rewrite_examples.into_iter().enumerate() {
+   /* */ for (i, (term_str, rule_str)) in rewrite_examples.into_iter().enumerate() {
         println!("--- Rewriting Example {} ---", i + 1);
 
         
@@ -139,4 +138,4 @@ fn parse_input_to_rule_tuple(input_str: &str) -> Result<((Node, i16), (Node, i16
     let mut parser = Parser::new(lexer);
    
     parser.parse_equality()
-}*/
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
+#[cfg(not(feature="term"))]
 mod lexer;
-mod parser;
+mod parser; 
 mod term;
 use lexer::Lexer;
 use parser::{Parser, Node,ParserError}; // Import what you need from parser
 
 
-use crate::term::Term;
+//use crate::term::Term;
 
 
 fn main() {
@@ -65,11 +66,11 @@ fn main() {
 
     };
      
-        let term1 = Term{term: node1.0.0,size:node1.0.1 };
+       // let term1 = Term{term: node1.0.0,size:node1.0.1 };
           
-        let rewrittenterm = term1.rewriteby(((&node2.0.0,node2.0.1),(&node2.1.0,node2.1.1)));
-        let term2 = Term{term:node2.0.0,size:node2.0.1};  
-        println!("By the law \"{}\", \"{}\" => \"{}\"", term2, term1, rewrittenterm);
+       // let rewrittenterm = term1.rewriteby(((&node2.0.0,node2.0.1),(&node2.1.0,node2.1.1)));
+      //  let term2 = Term{term:node2.0.0,size:node2.0.1};  
+       // println!("By the law \"{}\", \"{}\" => \"{}\"", term2, term1, rewrittenterm);
     
 
     let rewrite_examples = vec![
@@ -94,7 +95,8 @@ fn main() {
         // Example 10: Complex expression with multiple potential matches (only one applies per pass)
         ("(a + 0) * (b + 0)", "x + 0 = x"), // Should simplify both sides
     ];
-    for (i, (term_str, rule_str)) in rewrite_examples.into_iter().enumerate() {
+}
+   /*  for (i, (term_str, rule_str)) in rewrite_examples.into_iter().enumerate() {
         println!("--- Rewriting Example {} ---", i + 1);
 
         
@@ -137,4 +139,4 @@ fn parse_input_to_rule_tuple(input_str: &str) -> Result<((Node, i16), (Node, i16
     let mut parser = Parser::new(lexer);
    
     parser.parse_equality()
-}
+}*/

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,7 +7,7 @@ pub enum Node{
     Number(i64),
     Variable(char),
     BinaryOp(Box<Node>,Operator,Box<Node>),
-    UnaryOp(Operator,Box<Node>)
+  //  UnaryOp(Operator,Box<Node>)
 }
 
 
@@ -17,7 +17,7 @@ impl Node{
     match (self, other) {
         (Node::Number(_),Node::Number(_)) => true, 
         (Node::BinaryOp(_,op_self,_), Node::BinaryOp(_,op_other,_))=> op_self == op_other,
-        (Node::UnaryOp(op_self,_ ),Node::UnaryOp(op_other,_ ))=> op_self == op_other,
+     //   (Node::UnaryOp(op_self,_ ),Node::UnaryOp(op_other,_ ))=> op_self == op_other,
         (Node::Variable(_),_)=>true,
         _ => false,
 
@@ -151,7 +151,7 @@ impl Parser {
             //add option for variable, then for left parenthesis? -a+b is variable -(a+b) is
             else if let TokenType::Variable(value ) =self.current_token{
                 self.expect_and_advance(TokenType::Variable(value))?;
-                Ok((Node::UnaryOp(Operator::Subtract,Box::new(Node::Variable((value)))),0))
+                Ok((Node::BinaryOp(Box::new(Node::Number(0)),Operator::Subtract,Box::new(Node::Variable(value))),0))
                 
 
 
@@ -160,7 +160,7 @@ impl Parser {
                 self.expect_and_advance(TokenType::LParen)?;
                 let(node, opsnumber) = self.parse_term()?;
                 self.expect_and_advance(TokenType::RParen)?;
-                Ok((Node::UnaryOp(Operator::Subtract,Box::new(node)),opsnumber))
+                Ok((Node::BinaryOp(Box::new(Node::Number(0)),Operator::Subtract,Box::new(node)),opsnumber))
                 
 
             }
@@ -318,76 +318,7 @@ impl fmt::Display for Node {
                 // to consider operator precedence and associativity.
                 write!(f, "({} {} {})", lhs, op_str, rhs)
             }
-            Node::UnaryOp(op,rhs) => {
-                write!(f,"(- {})",rhs)
-
-            }
+           
         }
-    }
-}
-
-
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn testsimpleunaryopnumber(){
-        let number = "-2".to_string();
-        let lexer = Lexer::new(number);
-        let mut parser = Parser::new(lexer);
-        let node = match parser.parse_equality(){
-        Ok(node) =>{node 
-            
-
-
-        }
-        Err(e)=>{
-        eprintln!("Error parsing term \"{}\": {:?}", "-2", e);
-        ((Node::Variable('f'),0),(Node::Variable('f'),0))
-
-    }};
-     println!("{}",node.0.0);
-     assert_eq!(node.0.0, Node::Number(-2)) 
-     
-    }
-
-    #[test]
-    fn testsimpleunaryvariable(){
-        let variable = "-a".to_string();
-        let lexer = Lexer::new(variable);
-        let mut parser = Parser::new(lexer);
-        let node = match parser.parse_equality(){
-            Ok(node) => {
-                node
-            }
-            Err(e) => {
-            eprintln!("Error parsing term \"{}\";{:?}","-2",e);
-            ((Node::Variable('f'),0),(Node::Variable('f'),0))
-
-
-            }};
-            println!("{}",node.0.0);
-            assert_eq!(node.0.0,Node::UnaryOp(Operator::Subtract,Box::new(Node::Variable('a'))))
-    }
-    #[test]
-    fn testsimplenegativeparenthesis(){
-        let exp  = "-(a+b)".to_string();
-        let lexer = Lexer::new(exp);
-        let mut parser = Parser::new(lexer);
-        let node = match parser.parse_equality(){
-        Ok(node) => {
-            node
-
-        }
-
-        Err(e) => {
-            eprintln!("Error parsing term \"{}\";{:?}","-2",e);
-            ((Node::Variable('f'),0),(Node::Variable('f'),0))
-
-
-            }};
-        println!("{}",node.0.0);
-
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -130,7 +130,7 @@ fn complexitysize(&self)-> i16{// this is when number of operations is the same
 
 
                 }
-               // Node::UnaryOp(_,rhs)=> rec(rhs) // idk if it should add 1 or not we'll see  
+                Node::UnaryOp(_,rhs)=> rec(rhs) // idk if it should add 1 or not we'll see  
 
             }
 
@@ -171,14 +171,19 @@ pub fn rewriteby(&self, law:((&Node,i16),(&Node,i16)))-> Term{
             Node::BinaryOp(lhs,op,rhs) => {
                 let (new_lhs,lhsize) = rec(lhs,rule_pattern,subst_pattern);
                 let (new_rhs,rhsize) = rec(rhs,rule_pattern,subst_pattern);
+                
+                
                 (Node::BinaryOp(Box::new(new_lhs),*op,Box::new(new_rhs)),lhsize + rhsize +1) 
 
-
+            
+            
             }
-         /*    Node::UnaryOp(op,lhs) => {// for now the only op is minus 
-                let 
-
-            }*/ 
+             Node::UnaryOp(op,rhs) => {// for now the only op is minus 
+                let (new_rhs,rhsize)= rec(rhs,rule_pattern,subst_pattern);
+                let (new_lhs,lhsize)= rec(&Node::Number(0),rule_pattern,subst_pattern);// so here we consider -a to be 0 - a 
+                // possible issue -- a :c 
+                (Node::BinaryOp(Box::new(new_lhs),*op,Box::new(new_rhs)),lhsize + rhsize + 1)
+            }
             Node::Number(val) => (Node::Number(*val),0),
             Node::Variable(c) => (Node::Variable(*c),0)
 
@@ -332,7 +337,19 @@ pub fn nodesubst(snode:&Node,relations:&HashMap<char,Node>)->(Node,i16){
         Node::BinaryOp(lhs,op ,rhs ) => {
             let (new_lhs,lhsize) = nodesubst(lhs,relations); 
             let (new_rhs ,rhsize)= nodesubst(rhs, relations);
-            (Node::BinaryOp(Box::new(new_lhs),*op,Box::new(new_rhs)),lhsize + rhsize +1)
+            if op == &Operator::Subtract  {
+                (Node::UnaryOp(Operator::Subtract,Box::new(new_rhs)),rhsize + 1)
+
+            }
+            else {
+            (Node::BinaryOp(Box::new(new_lhs),*op,Box::new(new_rhs)),lhsize + rhsize +1)}
+            
+
+        }
+        Node::UnaryOp(op,rhs) => {
+            let (new_lhs,lhsize) = nodesubst(&Node::Number(0),relations);
+            let (new_rhs,rhsize) = nodesubst(rhs,relations);
+            (Node::BinaryOp(Box::new(new_lhs),*op,Box::new(new_rhs)),lhsize + rhsize + 1)
 
 
         }
@@ -355,7 +372,10 @@ pub fn countsize(node:&Node)->i16{
             return countsize(lhs) + countsize(rhs) + 1;
 
         }
+        Node::UnaryOp(_,rhs ) => {
+            return countsize(rhs) + 1; 
 
+        }
 
     }
 
@@ -576,4 +596,3 @@ mod tests {
         assert!(term_b < term_a, "Term B should be less than Term A using '<' operator");
     }
 }
-     

--- a/src/term.rs
+++ b/src/term.rs
@@ -120,7 +120,7 @@ impl Term{
 
 /// returns the number of operations in a term 
 fn complexitysize(&self)-> i16{// this is when number of operations is the same 
-   
+   // wtf u're telling me i don't account for the lhs? wtf is going on ohh nvm this is the one when equality ok
     fn rec(node:&Node)->i16{
             match node {
                 Node::Number(_) => 0,
@@ -130,7 +130,7 @@ fn complexitysize(&self)-> i16{// this is when number of operations is the same
 
 
                 }
-
+                Node::UnaryOp(_,rhs)=> rec(rhs) // idk if it should add 1 or not we'll see  
 
             }
 
@@ -573,3 +573,4 @@ mod tests {
         assert!(term_b < term_a, "Term B should be less than Term A using '<' operator");
     }
 }
+     

--- a/src/term.rs
+++ b/src/term.rs
@@ -130,7 +130,7 @@ fn complexitysize(&self)-> i16{// this is when number of operations is the same
 
 
                 }
-                Node::UnaryOp(_,rhs)=> rec(rhs) // idk if it should add 1 or not we'll see  
+               // Node::UnaryOp(_,rhs)=> rec(rhs) // idk if it should add 1 or not we'll see  
 
             }
 
@@ -175,7 +175,10 @@ pub fn rewriteby(&self, law:((&Node,i16),(&Node,i16)))-> Term{
 
 
             }
+         /*    Node::UnaryOp(op,lhs) => {// for now the only op is minus 
+                let 
 
+            }*/ 
             Node::Number(val) => (Node::Number(*val),0),
             Node::Variable(c) => (Node::Variable(*c),0)
 


### PR DESCRIPTION
## Unary operator was urgent a month ago, time to add it 
### Focus on minus 
- [x] parser rewrite/fix 
- [x] term rewriting implementation 

My current implementation only works for minus in the long run and considers unary minus to be 0 - smt 
which would work for some cases, but things like -(a+b) = -a - b turn into (0-a) + (0 -b) which is not cool :c 